### PR TITLE
fix: 커밋 메시지 한글도 가능하도록 수정

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,24 +1,8 @@
+const type = ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'refactor', 'revert', 'style', 'test'];
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
-    'type-enum': [
-      2,
-      'always',
-      [
-        'build',
-        'chore',
-        'ci',
-        'docs',
-        'feat',
-        'fix',
-        'perf',
-        'refactor',
-        'revert',
-        'style',
-        'test',
-        'sample',
-      ],
-    ],
+    'type-enum': [2, 'always', type],
   },
 };


### PR DESCRIPTION
기존 commit-lint 설정의 subject-case rule로 인해 한글 관련 커밋이 정상적으로 작동하지 않았기에 이를 수정함.